### PR TITLE
Updated gcfg dependency.

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
     "os/user"
     "path/filepath"
 
-    "code.google.com/p/gcfg"
+    "github.com/scalingdata/gcfg"
 )
 
 


### PR DESCRIPTION
I updated the gcfg dependency from code.google.com to one used by [kubernetes](https://github.com/kubernetes/kubernetes/pull/12227) and others. This is required after code.google.com shut down earlier this year.

There are [likely other options](https://godoc.org/?q=gcfg) but this appears to be the most popular replacement.

Thanks for putting this out there!
